### PR TITLE
feat: create aks apim structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Repository to create the Kubernetes infra.
 ## Replace with your actual subscription ID
 
 ```bash
-az ad sp create-for-rbac --name "fase3ServicePrincipalInfra" --role Contributor --scopes /subscriptions/5359dabe-cccb-424a-b43f-f1b7ec544dc1
+az ad sp create-for-rbac --name "fase3ServicePrincipalInfra" --role Owner --scopes /subscriptions/5359dabe-cccb-424a-b43f-f1b7ec544dc1
 ```
 
 Store the generated value in a safe place.

--- a/main.tf
+++ b/main.tf
@@ -69,6 +69,25 @@ module "infra_aks" {
   location            = module.infra_resource_group.location
   resource_group_name = module.infra_resource_group.name
   subnet_id           = module.infra_vnet_subnets.snet-aks-id
+
+  depends_on = [module.infra_vnet_subnets]
+}
+
+resource "kubectl_manifest" "internal_nginx" {
+  yaml_body  = <<YAML
+apiVersion: approuting.kubernetes.azure.com/v1alpha1
+kind: NginxIngressController
+metadata:
+  name: nginx-internal-static
+spec:
+  ingressClassName: nginx-internal-static
+  controllerNamePrefix: nginx-internal-static
+  loadBalancerAnnotations: 
+    service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+    service.beta.kubernetes.io/azure-load-balancer-ipv4: "10.10.0.10"
+YAML
+  wait       = true
+  depends_on = [module.infra_aks]
 }
 
 #endregion

--- a/main.tf
+++ b/main.tf
@@ -10,12 +10,6 @@ output "infra_resource_group_name" {
 
 }
 
-output "infra_resource_group_id" {
-  value       = module.infra_resource_group.id
-  description = "The ID of the resource group created by the module"
-
-}
-
 output "infra_resource_group_location" {
   value       = module.infra_resource_group.location
   description = "The location of the resource group created by the module"
@@ -39,4 +33,21 @@ output "infra_acr_name" {
 output "infra_acr_login_server" {
   value       = module.infra_acr.login_server
   description = "The login server of the Azure Container Registry created by the module"
+}
+
+module "infra_vnet_subnets" {
+  source              = "./modules/azure-virtual-networks"
+  location            = module.infra_resource_group.location
+  resource_group_name = module.infra_resource_group.name
+}
+
+module "infra_apim" {
+  source              = "./modules/azure-api-management"
+  apim_name           = var.apim_name
+  location            = module.infra_resource_group.location
+  resource_group_name = module.infra_resource_group.name
+  nsg_name            = var.nsg_name
+  subnet_id           = module.infra_vnet_subnets.snet-apim-id
+  publisher_email     = var.publisher_email
+
 }

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,5 @@
+#region Resource Group
+
 module "infra_resource_group" {
   source   = "./modules/azure-resource-group"
   name     = var.resource_group_name
@@ -15,7 +17,9 @@ output "infra_resource_group_location" {
   description = "The location of the resource group created by the module"
 
 }
+#endregion
 
+#region ACR
 module "infra_acr" {
   source              = "./modules/azure-container-registry"
   name                = var.acr_name
@@ -34,13 +38,17 @@ output "infra_acr_login_server" {
   value       = module.infra_acr.login_server
   description = "The login server of the Azure Container Registry created by the module"
 }
+#endregion
 
+#region VNET and Subnets
 module "infra_vnet_subnets" {
   source              = "./modules/azure-virtual-networks"
   location            = module.infra_resource_group.location
   resource_group_name = module.infra_resource_group.name
 }
+#endregion
 
+#region APIM
 module "infra_apim" {
   source              = "./modules/azure-api-management"
   apim_name           = var.apim_name
@@ -51,3 +59,16 @@ module "infra_apim" {
   publisher_email     = var.publisher_email
 
 }
+#endregion
+
+#region AKS
+
+module "infra_aks" {
+  source              = "./modules/azure-kubernetes-cluster"
+  name                = var.aks_name
+  location            = module.infra_resource_group.location
+  resource_group_name = module.infra_resource_group.name
+  subnet_id           = module.infra_vnet_subnets.snet-aks-id
+}
+
+#endregion

--- a/modules/azure-api-management/main.tf
+++ b/modules/azure-api-management/main.tf
@@ -1,0 +1,170 @@
+resource "azurerm_network_security_group" "group118fase3infransg" {
+  name                = var.nsg_name
+  location            = var.location
+  resource_group_name = var.resource_group_name
+}
+
+resource "azurerm_subnet_network_security_group_association" "nsg-association" {
+  subnet_id                 = var.subnet_id
+  network_security_group_id = azurerm_network_security_group.group118fase3infransg.id
+  
+}
+
+resource "azurerm_network_security_rule" "allow-inbound-infra-lb" {
+  resource_group_name         = var.resource_group_name
+  network_security_group_name = azurerm_network_security_group.group118fase3infransg.name
+  name                        = "allow-inbound-infra-lb"
+  access                      = "Allow"
+  priority                    = 1000 # between 100 and 4096, must be unique, The lower the priority number, the higher the priority of the rule.
+  direction                   = "Inbound"
+  protocol                    = "Tcp"               # Tcp, Udp, Icmp, Esp, Ah or * (which matches all).
+  source_address_prefix       = "AzureLoadBalancer" # CIDR or source IP range or * to match any IP, Supports Tags like VirtualNetwork, AzureLoadBalancer and Internet.
+  source_port_range           = "*"                 # between 0 and 65535 or * to match any
+  destination_address_prefix  = "VirtualNetwork"
+  destination_port_range      = "6390"
+}
+
+resource "azurerm_network_security_rule" "allow-inbound-apim" {
+  resource_group_name         = var.resource_group_name
+  network_security_group_name = azurerm_network_security_group.group118fase3infransg.name
+  name                        = "allow-inbound-apim"
+  access                      = "Allow"
+  priority                    = 1010 # between 100 and 4096, must be unique, The lower the priority number, the higher the priority of the rule.
+  direction                   = "Inbound"
+  protocol                    = "Tcp"           # Tcp, Udp, Icmp, Esp, Ah or * (which matches all).
+  source_address_prefix       = "ApiManagement" # CIDR or source IP range or * to match any IP, Supports Tags like VirtualNetwork, AzureLoadBalancer and Internet.
+  source_port_range           = "*"             # between 0 and 65535 or * to match any
+  destination_address_prefix  = "VirtualNetwork"
+  destination_port_range      = "3443"
+}
+
+resource "azurerm_network_security_rule" "allow-inbound-internet-http" {
+  resource_group_name         = var.resource_group_name
+  network_security_group_name = azurerm_network_security_group.group118fase3infransg.name
+  name                        = "allow-inbound-internet-http"
+  access                      = "Allow"
+  priority                    = 1020 # between 100 and 4096, must be unique, The lower the priority number, the higher the priority of the rule.
+  direction                   = "Inbound"
+  protocol                    = "Tcp"      # Tcp, Udp, Icmp, Esp, Ah or * (which matches all).
+  source_address_prefix       = "Internet" # CIDR or source IP range or * to match any IP, Supports Tags like VirtualNetwork, AzureLoadBalancer and Internet.
+  source_port_range           = "*"        # between 0 and 65535 or * to match any
+  destination_address_prefix  = "VirtualNetwork"
+  destination_port_range      = "80"
+}
+
+resource "azurerm_network_security_rule" "allow-inbound-internet-https" {
+  resource_group_name         = var.resource_group_name
+  network_security_group_name = azurerm_network_security_group.group118fase3infransg.name
+  name                        = "allow-inbound-internet-https"
+  access                      = "Allow"
+  priority                    = 1030 # between 100 and 4096, must be unique, The lower the priority number, the higher the priority of the rule.
+  direction                   = "Inbound"
+  protocol                    = "Tcp"      # Tcp, Udp, Icmp, Esp, Ah or * (which matches all).
+  source_address_prefix       = "Internet" # CIDR or source IP range or * to match any IP, Supports Tags like VirtualNetwork, AzureLoadBalancer and Internet.
+  source_port_range           = "*"        # between 0 and 65535 or * to match any
+  destination_address_prefix  = "VirtualNetwork"
+  destination_port_range      = "443"
+}
+
+resource "azurerm_network_security_rule" "allow-outbound-azuresql" {
+  count                       = 1 # enable if using Azure SQL
+  resource_group_name         = var.resource_group_name
+  network_security_group_name = azurerm_network_security_group.group118fase3infransg.name
+  name                        = "allow-outbound-azure-sql"
+  access                      = "Allow"
+  priority                    = 1030 # between 100 and 4096, must be unique, The lower the priority number, the higher the priority of the rule.
+  direction                   = "Outbound"
+  protocol                    = "Tcp"            # Tcp, Udp, Icmp, Esp, Ah or * (which matches all).
+  source_address_prefix       = "VirtualNetwork" # CIDR or source IP range or * to match any IP, Supports Tags like VirtualNetwork, AzureLoadBalancer and Internet.
+  source_port_range           = "*"              # between 0 and 65535 or * to match any
+  destination_address_prefix  = "SQL"
+  destination_port_range      = "1433"
+}
+
+
+resource "azurerm_network_security_rule" "allow-outbound-storage" {
+  resource_group_name         = var.resource_group_name
+  network_security_group_name = azurerm_network_security_group.group118fase3infransg.name
+  name                        = "allow-outbound-storage"
+  access                      = "Allow"
+  priority                    = 1000
+  direction                   = "Outbound"
+  protocol                    = "Tcp"
+  source_address_prefix       = "VirtualNetwork"
+  source_port_range           = "*"
+  destination_address_prefix  = "Storage"
+  destination_port_range      = "443"
+}
+
+resource "azurerm_network_security_rule" "allow-outbound-keyvault" {
+  resource_group_name         = var.resource_group_name
+  network_security_group_name = azurerm_network_security_group.group118fase3infransg.name
+  name                        = "allow-outbound-keyvault"
+  access                      = "Allow"
+  priority                    = 1010
+  direction                   = "Outbound"
+  protocol                    = "Tcp"
+  source_address_prefix       = "VirtualNetwork"
+  source_port_range           = "*"
+  destination_address_prefix  = "AzureKeyVault"
+  destination_port_range      = "443"
+}
+
+resource "azurerm_network_security_rule" "allow-outbound-eventhub" {
+  resource_group_name         = var.resource_group_name
+  network_security_group_name = azurerm_network_security_group.group118fase3infransg.name
+  name                        = "allow-outbound-eventhub"
+  access                      = "Allow"
+  priority                    = 1020
+  direction                   = "Outbound"
+  protocol                    = "Tcp"
+  source_address_prefix       = "VirtualNetwork"
+  source_port_range           = "*"
+  destination_address_prefix  = "EventHub"
+  destination_port_ranges     = ["5671", "5672", "443"]
+}
+
+resource "azurerm_network_security_rule" "allow-outbound-azuremonitor" {
+  resource_group_name         = var.resource_group_name
+  network_security_group_name = azurerm_network_security_group.group118fase3infransg.name
+  name                        = "allow-outbound-azuremonitor"
+  access                      = "Allow"
+  priority                    = 1040
+  direction                   = "Outbound"
+  protocol                    = "Tcp"
+  source_address_prefix       = "VirtualNetwork"
+  source_port_range           = "*"
+  destination_address_prefix  = "AzureMonitor"
+  destination_port_range      = "443"
+}
+
+resource "azurerm_network_security_rule" "allow-outbound-azureconnectors" {
+  resource_group_name         = var.resource_group_name
+  network_security_group_name = azurerm_network_security_group.group118fase3infransg.name
+  name                        = "allow-outbound-azureconnectors"
+  access                      = "Allow"
+  priority                    = 1050
+  direction                   = "Outbound"
+  protocol                    = "Tcp"
+  source_address_prefix       = "VirtualNetwork"
+  source_port_range           = "*"
+  destination_address_prefix  = "AzureConnectors"
+  destination_port_ranges     = ["443", "80"]
+}
+
+resource "azurerm_api_management" "group118fase3infraapim" {
+  name                          = var.apim_name
+  location                      = var.location
+  resource_group_name           = var.resource_group_name
+  publisher_name                = "Group118"
+  sku_name                      = "Developer_1"
+  virtual_network_type          = "External"
+  publisher_email               = "group118@example.com"
+  public_network_access_enabled = true
+
+  virtual_network_configuration {
+    subnet_id = var.subnet_id
+  }
+
+  depends_on = [azurerm_subnet_network_security_group_association.nsg-association]
+}

--- a/modules/azure-api-management/variables.tf
+++ b/modules/azure-api-management/variables.tf
@@ -1,0 +1,31 @@
+variable "apim_name" {
+  description = "The name of the Azure API Management service instance."
+  type        = string
+}
+
+variable "location" {
+  description = "The Azure region where the resources will be created."
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "The name of the resource group where the resources will be created."
+  type        = string
+
+}
+
+variable "nsg_name" {
+  description = "The name of the Network Security Group."
+  type        = string
+}
+
+variable "subnet_id" {
+  description = "The ID of the subnet to associate with the NSG."
+  type        = string
+}
+
+variable "publisher_email" {
+  description = "The email address of the API Management publisher."
+  type        = string
+  default     = "group118@example.com"
+}

--- a/modules/azure-kubernetes-cluster/main.tf
+++ b/modules/azure-kubernetes-cluster/main.tf
@@ -1,0 +1,39 @@
+resource "azurerm_kubernetes_cluster" "group118fase3infraaks" {
+  name                    = var.name
+  location                = var.location
+  resource_group_name     = var.resource_group_name
+  dns_prefix              = var.name
+  private_cluster_enabled = true
+  private_dns_zone_id     = "System"
+
+  network_profile {
+    network_plugin      = "azure"
+    network_plugin_mode = "overlay"
+    service_cidr        = "10.10.0.0/16" # Add required service CIDR
+    dns_service_ip      = "10.10.0.10"   # Add required DNS service IP    
+  }
+
+  default_node_pool {
+    name                        = "default"
+    temporary_name_for_rotation = "defaulttemp"
+    node_count                  = 1
+    vm_size                     = "Standard_E2s_v3" # TODO: Procurar tamanhos menores e mudar regiao: Standard_D2s_v3
+    os_sku                      = "AzureLinux"
+    vnet_subnet_id              = var.subnet_id
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+resource "terraform_data" "aks-get-credentials" {
+  triggers_replace = [
+    azurerm_kubernetes_cluster.group118fase3infraaks.id
+  ]
+
+  provisioner "local-exec" {
+    command = "az aks get-credentials -n ${azurerm_kubernetes_cluster.group118fase3infraaks.name} -g ${azurerm_kubernetes_cluster.group118fase3infraaks.resource_group_name} --overwrite-existing"
+
+  }
+}

--- a/modules/azure-kubernetes-cluster/main.tf
+++ b/modules/azure-kubernetes-cluster/main.tf
@@ -3,21 +3,18 @@ resource "azurerm_kubernetes_cluster" "group118fase3infraaks" {
   location                = var.location
   resource_group_name     = var.resource_group_name
   dns_prefix              = var.name
-  private_cluster_enabled = true
-  private_dns_zone_id     = "System"
+  private_cluster_enabled = false
 
   network_profile {
     network_plugin      = "azure"
     network_plugin_mode = "overlay"
-    service_cidr        = "10.10.0.0/16" # Add required service CIDR
-    dns_service_ip      = "10.10.0.10"   # Add required DNS service IP    
   }
 
   default_node_pool {
     name                        = "default"
     temporary_name_for_rotation = "defaulttemp"
     node_count                  = 1
-    vm_size                     = "Standard_E2s_v3" # TODO: Procurar tamanhos menores e mudar regiao: Standard_D2s_v3
+    vm_size                     = "Standard_E4s_v3" # TODO: Procurar tamanhos menores e mudar regiao: Standard_D2s_v3
     os_sku                      = "AzureLinux"
     vnet_subnet_id              = var.subnet_id
   }
@@ -25,6 +22,17 @@ resource "azurerm_kubernetes_cluster" "group118fase3infraaks" {
   identity {
     type = "SystemAssigned"
   }
+
+  web_app_routing {
+    dns_zone_ids = []
+  }
+}
+
+resource "azurerm_role_assignment" "owner-tocreate-nginx" {
+  scope                = var.subnet_id
+  role_definition_name = "Owner"
+  principal_id         = azurerm_kubernetes_cluster.group118fase3infraaks.identity.0.principal_id
+
 }
 
 resource "terraform_data" "aks-get-credentials" {

--- a/modules/azure-kubernetes-cluster/outputs.tf
+++ b/modules/azure-kubernetes-cluster/outputs.tf
@@ -1,10 +1,35 @@
 output "name" {
   description = "The name of the AKS cluster."
   value       = azurerm_kubernetes_cluster.group118fase3infraaks.name
-
 }
 
 output "id" {
   description = "The ID of the AKS cluster."
   value       = azurerm_kubernetes_cluster.group118fase3infraaks.id
+}
+
+output "kube_config_raw" {
+  description = "The raw kube config of the AKS cluster."
+  value       = azurerm_kubernetes_cluster.group118fase3infraaks.kube_config_raw
+
+}
+
+output "client_certificate" {
+  description = "The client certificate of the AKS cluster."
+  value       = azurerm_kubernetes_cluster.group118fase3infraaks.kube_config.0.client_certificate
+}
+
+output "client_key" {
+  description = "The client key of the AKS cluster."
+  value       = azurerm_kubernetes_cluster.group118fase3infraaks.kube_config.0.client_key
+}
+
+output "cluster_ca_certificate" {
+  description = "The cluster CA certificate of the AKS cluster."
+  value       = azurerm_kubernetes_cluster.group118fase3infraaks.kube_config.0.cluster_ca_certificate
+}
+
+output "host" {
+  description = "The host of the AKS cluster."
+  value       = azurerm_kubernetes_cluster.group118fase3infraaks.kube_config.0.host
 }

--- a/modules/azure-kubernetes-cluster/outputs.tf
+++ b/modules/azure-kubernetes-cluster/outputs.tf
@@ -1,0 +1,10 @@
+output "name" {
+  description = "The name of the AKS cluster."
+  value       = azurerm_kubernetes_cluster.group118fase3infraaks.name
+
+}
+
+output "id" {
+  description = "The ID of the AKS cluster."
+  value       = azurerm_kubernetes_cluster.group118fase3infraaks.id
+}

--- a/modules/azure-kubernetes-cluster/variables.tf
+++ b/modules/azure-kubernetes-cluster/variables.tf
@@ -1,0 +1,20 @@
+variable "name" {
+  description = "The name of the AKS cluster."
+  type        = string
+
+}
+
+variable "resource_group_name" {
+  description = "The name of the resource group."
+  type        = string
+}
+
+variable "location" {
+  description = "The location where the AKS cluster will be created."
+  type        = string
+}
+
+variable "subnet_id" {
+  description = "The ID of the subnet where the AKS cluster will be deployed."
+  type        = string
+}

--- a/modules/azure-virtual-networks/main.tf
+++ b/modules/azure-virtual-networks/main.tf
@@ -1,0 +1,22 @@
+resource "azurerm_virtual_network" "vnet-spoke" {
+  name                = "vnet-spoke"
+  address_space       = ["10.0.0.0/16"]
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  dns_servers = null
+}
+
+resource "azurerm_subnet" "snet-aks" {
+  name                 = "snet-aks"
+  resource_group_name  = azurerm_virtual_network.vnet-spoke.resource_group_name
+  virtual_network_name = azurerm_virtual_network.vnet-spoke.name
+  address_prefixes     = ["10.0.1.0/24"]
+}
+
+
+resource "azurerm_subnet" "snet-apim" {
+  name                 = "snet-apim"
+  resource_group_name  = azurerm_virtual_network.vnet-spoke.resource_group_name
+  virtual_network_name = azurerm_virtual_network.vnet-spoke.name
+  address_prefixes     = ["10.0.2.0/24"]
+}

--- a/modules/azure-virtual-networks/main.tf
+++ b/modules/azure-virtual-networks/main.tf
@@ -1,6 +1,6 @@
 resource "azurerm_virtual_network" "vnet-spoke" {
   name                = "vnet-spoke"
-  address_space       = ["10.0.0.0/16"]
+  address_space       = ["10.10.0.0/16"]
   location            = var.location
   resource_group_name = var.resource_group_name
   dns_servers = null
@@ -10,7 +10,7 @@ resource "azurerm_subnet" "snet-aks" {
   name                 = "snet-aks"
   resource_group_name  = azurerm_virtual_network.vnet-spoke.resource_group_name
   virtual_network_name = azurerm_virtual_network.vnet-spoke.name
-  address_prefixes     = ["10.0.1.0/24"]
+  address_prefixes     = ["10.10.0.0/24"]
 }
 
 
@@ -18,5 +18,5 @@ resource "azurerm_subnet" "snet-apim" {
   name                 = "snet-apim"
   resource_group_name  = azurerm_virtual_network.vnet-spoke.resource_group_name
   virtual_network_name = azurerm_virtual_network.vnet-spoke.name
-  address_prefixes     = ["10.0.2.0/24"]
+  address_prefixes     = ["10.10.1.0/24"]
 }

--- a/modules/azure-virtual-networks/outputs.tf
+++ b/modules/azure-virtual-networks/outputs.tf
@@ -1,0 +1,11 @@
+output "snet-aks-id" {
+  value = azurerm_subnet.snet-aks.id
+}
+
+output "snet-apim-id" {
+  value = azurerm_subnet.snet-apim.id
+}
+
+output "vnet-spoke-id" {
+  value = azurerm_virtual_network.vnet-spoke.id
+}

--- a/modules/azure-virtual-networks/variables.tf
+++ b/modules/azure-virtual-networks/variables.tf
@@ -1,0 +1,11 @@
+variable "resource_group_name" {
+  description = "The name of the resource group where the container registry will be created."
+  type        = string
+
+}
+
+variable "location" {
+  description = "The Azure region where the container registry will be created."
+  type        = string
+
+}

--- a/provider.tf
+++ b/provider.tf
@@ -3,6 +3,14 @@ provider "azurerm" {
   features {}
 }
 
+provider "kubectl" {
+  host                   = module.infra_aks.host
+  cluster_ca_certificate = base64decode(module.infra_aks.cluster_ca_certificate)
+  client_certificate     = base64decode(module.infra_aks.client_certificate)
+  client_key             = base64decode(module.infra_aks.client_key)
+  load_config_file = false
+}
+
 # We strongly recommend using the required_providers block to set the
 # Azure Provider source and version being used
 terraform {
@@ -10,6 +18,10 @@ terraform {
     azurerm = {
       source  = "hashicorp/azurerm"
       version = "=4.4.0"
+    }
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = ">= 1.7.0"
     }
   }
 }

--- a/provider.tf
+++ b/provider.tf
@@ -8,7 +8,7 @@ provider "kubectl" {
   cluster_ca_certificate = base64decode(module.infra_aks.cluster_ca_certificate)
   client_certificate     = base64decode(module.infra_aks.client_certificate)
   client_key             = base64decode(module.infra_aks.client_key)
-  load_config_file = false
+  load_config_file       = false
 }
 
 # We strongly recommend using the required_providers block to set the

--- a/variables.tf
+++ b/variables.tf
@@ -33,3 +33,9 @@ variable "publisher_email" {
   type        = string
   default     = "group118@example.com"
 }
+
+variable "aks_name" {
+  description = "The name of the AKS cluster"
+  type        = string
+  default     = "grupo118fase3infraaks"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -15,3 +15,21 @@ variable "acr_name" {
   type        = string
   default     = "grupo118fase3infraacr"
 }
+
+variable "apim_name" {
+  description = "The name of the Azure API Management service instance"
+  type        = string
+  default     = "grupo118fase3infraapim"
+}
+
+variable "nsg_name" {
+  description = "The name of the Network Security Group"
+  type        = string
+  default     = "grupo118fase3infransg"
+}
+
+variable "publisher_email" {
+  description = "The email address of the API Management publisher"
+  type        = string
+  default     = "group118@example.com"
+}


### PR DESCRIPTION
This pull request introduces major enhancements to the infrastructure provisioning for Kubernetes on Azure. The changes add modules for virtual networks, subnets, Azure API Management (APIM), and Azure Kubernetes Service (AKS), along with supporting variables, outputs, and provider configuration. The updates also improve network security by defining a set of Network Security Group (NSG) rules and automate the deployment of an internal NGINX ingress controller. Overall, the codebase is now more modular and better organized for Azure resource management.

**Infrastructure Module Additions and Organization**
* Added new Terraform modules for Azure Virtual Networks (`azure-virtual-networks`), AKS (`azure-kubernetes-cluster`), and API Management (`azure-api-management`), including resource definitions, variables, and outputs for each. This modularizes the infrastructure and supports easier management and scaling. [[1]](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbR1-R2) [[2]](diffhunk://#diff-6242dc05fd29c4534b86c107046d75b3c883c067772ef62b433efd753898becbR1-R22) [[3]](diffhunk://#diff-9e4fb51155f0b3365671fa07849997cb6b35b96396473b4d3c41846052d33d7fR1-R47) [[4]](diffhunk://#diff-8763faebb9775a64b9d30b5f2f5fdef13ab0c95639433852b4aff89f906eb346R1-R31) [[5]](diffhunk://#diff-a5632205be46fc499892b48096de6e0adfc75e7ced5da44f82efe8068485d698R1-R20) [[6]](diffhunk://#diff-0e0f08f2b1ab84220187b6d5fafd10837b2815ffd276a549d31a4507d52e7c0bR1-R11) [[7]](diffhunk://#diff-7725ee227a1a08c88bd2a3619f0bd3954d40578db53c020b4f2316605c314f0aR1-R11) [[8]](diffhunk://#diff-7e69065c9897a3f53d713dec26e7df98404cc017ed3a0aaa32af962b0b8953a1R1-R35)

**Network Security Enhancements**
* Implemented a comprehensive set of NSG rules in `azure-api-management/main.tf` to control inbound and outbound traffic for APIM, including rules for load balancer, internet, Azure SQL, storage, key vault, event hub, Azure Monitor, and connectors. Also added subnet association for NSG.

**AKS Cluster and Ingress Automation**
* Provisioned AKS cluster with a default node pool and automated retrieval of cluster credentials. Added a role assignment for subnet ownership and automated deployment of an internal NGINX ingress controller using a `kubectl_manifest` resource. [[1]](diffhunk://#diff-9e4fb51155f0b3365671fa07849997cb6b35b96396473b4d3c41846052d33d7fR1-R47) [[2]](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbR41-R93)

**Provider and Output Configuration**
* Configured the `kubectl` provider to use AKS outputs for secure cluster access and updated the `terraform` block to include the required provider for Kubernetes management. [[1]](diffhunk://#diff-b1ce465309ea8053579092908d4a1eda1a02f48a6287db574dd2a2104935dd2fR6-R13) [[2]](diffhunk://#diff-b1ce465309ea8053579092908d4a1eda1a02f48a6287db574dd2a2104935dd2fR22-R25)
* Added outputs for AKS and network resources to expose key connection details and identifiers for downstream use. [[1]](diffhunk://#diff-0e0f08f2b1ab84220187b6d5fafd10837b2815ffd276a549d31a4507d52e7c0bR1-R11) [[2]](diffhunk://#diff-7e69065c9897a3f53d713dec26e7df98404cc017ed3a0aaa32af962b0b8953a1R1-R35)

**Variable and Documentation Updates**
* Added new variables to support the configuration of APIM, NSG, AKS, and publisher email, with sensible defaults for easier deployment. Also updated the documentation to reflect a change in Azure role assignment from Contributor to Owner for service principal creation. [[1]](diffhunk://#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288eR18-R41) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L8-R8)