### PR TITLE
feat: Update VM size, add ACR ID variable, and configure role assignment for AKS

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -69,6 +69,7 @@ module "infra_aks" {
   location            = module.infra_resource_group.location
   resource_group_name = module.infra_resource_group.name
   subnet_id           = module.infra_vnet_subnets.snet-aks-id
+  acr_id              = module.infra_acr.id
 
   depends_on = [module.infra_vnet_subnets]
 }

--- a/modules/azure-kubernetes-cluster/main.tf
+++ b/modules/azure-kubernetes-cluster/main.tf
@@ -4,6 +4,7 @@ resource "azurerm_kubernetes_cluster" "group118fase3infraaks" {
   resource_group_name     = var.resource_group_name
   dns_prefix              = var.name
   private_cluster_enabled = false
+  sku_tier                = "Free"
 
   network_profile {
     network_plugin      = "azure"
@@ -14,9 +15,11 @@ resource "azurerm_kubernetes_cluster" "group118fase3infraaks" {
     name                        = "default"
     temporary_name_for_rotation = "defaulttemp"
     node_count                  = 1
-    vm_size                     = "Standard_E4s_v3" # TODO: Procurar tamanhos menores e mudar regiao: Standard_D2s_v3
+    vm_size                     = "Standard_A4_v2" # TODO: Procurar tamanhos menores e mudar regiao: Standard_D2s_v3
     os_sku                      = "AzureLinux"
     vnet_subnet_id              = var.subnet_id
+    auto_scaling_enabled        = false
+    zones                       = []
   }
 
   identity {
@@ -24,7 +27,7 @@ resource "azurerm_kubernetes_cluster" "group118fase3infraaks" {
   }
 
   web_app_routing {
-    dns_zone_ids = []
+    dns_zone_ids             = []
   }
 }
 
@@ -33,6 +36,13 @@ resource "azurerm_role_assignment" "owner-tocreate-nginx" {
   role_definition_name = "Owner"
   principal_id         = azurerm_kubernetes_cluster.group118fase3infraaks.identity.0.principal_id
 
+}
+
+resource "azurerm_role_assignment" "acr-pull" {
+  principal_id                     = azurerm_kubernetes_cluster.group118fase3infraaks.identity.0.principal_id
+  role_definition_name             = "AcrPull"
+  scope                            = var.acr_id
+  skip_service_principal_aad_check = true
 }
 
 resource "terraform_data" "aks-get-credentials" {

--- a/modules/azure-kubernetes-cluster/variables.tf
+++ b/modules/azure-kubernetes-cluster/variables.tf
@@ -18,3 +18,8 @@ variable "subnet_id" {
   description = "The ID of the subnet where the AKS cluster will be deployed."
   type        = string
 }
+
+variable "acr_id" {
+  description = "The ID of the Azure Container Registry to grant pull access."
+  type        = string
+}

--- a/provider.tf
+++ b/provider.tf
@@ -17,7 +17,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=4.4.0"
+      version = "=4.41.0"
     }
     kubectl = {
       source  = "gavinbunney/kubectl"

--- a/variables.tf
+++ b/variables.tf
@@ -7,7 +7,7 @@ variable "resource_group_name" {
 variable "resource_group_location" {
   description = "The Azure region where resources will be created"
   type        = string
-  default     = "Brazil South"
+  default     = "East US"
 }
 
 variable "acr_name" {


### PR DESCRIPTION
This pull request introduces several infrastructure improvements and updates to the AKS (Azure Kubernetes Service) module and related resources. The most significant changes include granting the AKS cluster permission to pull images from Azure Container Registry (ACR), updating resource configurations for cost optimization, and upgrading provider versions for compatibility.

**Access and Permissions:**
* Added an `azurerm_role_assignment` resource to grant the AKS cluster the `AcrPull` role, allowing it to pull container images from the specified ACR (`acr_id`).
* Updated the AKS module to accept and pass the ACR ID, ensuring the cluster has the necessary registry access (`acr_id` variable and module input). [[1]](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbR72) [[2]](diffhunk://#diff-a5632205be46fc499892b48096de6e0adfc75e7ced5da44f82efe8068485d698R21-R25)

**Resource Configuration and Optimization:**
* Changed the default VM size for AKS node pool from `Standard_E4s_v3` to the more cost-effective `Standard_A4_v2`, and explicitly disabled autoscaling and zone distribution for simplicity.
* Set the AKS cluster `sku_tier` to `"Free"` to reduce costs.

**Provider and Regional Updates:**
* Upgraded the `azurerm` provider version from `4.4.0` to `4.41.0` for improved compatibility and features.
* Changed the default Azure region for resource creation from `"Brazil South"` to `"East US"` to align with deployment requirements.