### PR TITLE
feat: Add admin credentials outputs for Azure Container Registry and

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -34,10 +34,28 @@ output "infra_acr_name" {
 
 }
 
+output "infra_acr_id" {
+  value       = module.infra_acr.id
+  description = "The ID of the Azure Container Registry created by the module"
+
+}
+
 output "infra_acr_login_server" {
   value       = module.infra_acr.login_server
   description = "The login server of the Azure Container Registry created by the module"
 }
+
+output "infra_acr_username" {
+  value       = module.infra_acr.username
+  description = "The admin username of the Azure Container Registry created by the module"
+}
+
+output "infra_acr_password" {
+  value       = module.infra_acr.password
+  description = "The admin password of the Azure Container Registry created by the module"
+  sensitive   = true
+}
+
 #endregion
 
 #region VNET and Subnets

--- a/modules/azure-container-registry/main.tf
+++ b/modules/azure-container-registry/main.tf
@@ -2,5 +2,6 @@ resource "azurerm_container_registry" "group118fase3infraacr" {
   name                = var.name
   resource_group_name = var.resource_group_name
   location            = var.location
-  sku = var.sku
+  sku                 = var.sku
+  admin_enabled       = true
 }

--- a/modules/azure-container-registry/outputs.tf
+++ b/modules/azure-container-registry/outputs.tf
@@ -12,3 +12,13 @@ output "login_server" {
   description = "The login server of the container registry"
   value       = azurerm_container_registry.group118fase3infraacr.login_server
 }
+
+output "username" {
+  description = "The admin username for the Azure Container Registry (if enabled)."
+  value       = azurerm_container_registry.group118fase3infraacr.admin_username
+}
+
+output "password" {
+  description = "The admin password for the Azure Container Registry (if enabled)."
+  value       = azurerm_container_registry.group118fase3infraacr.admin_password
+}


### PR DESCRIPTION
This pull request enhances the Azure Container Registry (ACR) module by enabling admin access and exposing additional outputs for easier integration and management. The main changes focus on making admin credentials available and improving the module's usability.

**Azure Container Registry admin access:**

* Enabled admin access for the ACR by setting `admin_enabled = true` in `modules/azure-container-registry/main.tf`, allowing retrieval of admin credentials.

**New outputs for ACR credentials and identifiers:**

* Added outputs for admin `username` and `password` in `modules/azure-container-registry/outputs.tf`, making these credentials accessible when admin access is enabled.
* Added new outputs in `main.tf` for `infra_acr_id`, `infra_acr_username`, and sensitive `infra_acr_password`, exposing the registry's ID and admin credentials at the root module level.