### PR TITLE
feat: Refactor Terraform workflows to use template pipeline for resource management

### DIFF
--- a/.github/workflows/createresources.yml
+++ b/.github/workflows/createresources.yml
@@ -1,4 +1,4 @@
-name: 'Create Terraform Resources'
+name: Create Terraform Resources
 
 on:
   push:
@@ -9,94 +9,12 @@ on:
       - main
       - develop
 
-env:
-  ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-  ARM_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-  ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-  ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-  TF_API_TOKEN: ${{ secrets.TF_API_TOKEN }}
-
 jobs:
-  terraform-validate:
-    name: 'Terraform Validate'
-    runs-on: ubuntu-latest
-    environment: production
-
-    # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
-    defaults:
-      run:
-        shell: bash
-
-    steps:
-    # Checkout the repository to the GitHub Actions runner
-    - name: Checkout
-      uses: actions/checkout@v4
-
-    # Install the latest version of Terraform CLI 
-    - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v3
-      with:
-        cli_config_credentials_token: ${{ env.TF_API_TOKEN }}
-
-    # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
-    - name: Terraform Init
-      run: terraform init -input=false
-
-    # Checks that all Terraform configuration files adhere to a canonical format
-    - name: Terraform Format
-      run: terraform fmt -check
-
-  terraform-plan:
-    name: 'Terraform Plan'
-    needs: terraform-validate
-    runs-on: ubuntu-latest
-    environment: production
-
-    defaults:
-      run:
-        shell: bash
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-
-    - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v3
-      with:
-        cli_config_credentials_token: ${{ env.TF_API_TOKEN }}
-
-    - name: Terraform Init
-      run: terraform init -input=false
-
-    - name: Terraform Plan
-      id: plan
-      run: |
-        terraform plan -input=false -detailed-exitcode
-        echo "exitcode=$?" >> $GITHUB_OUTPUT
-      continue-on-error: true
-      
-  terraform-apply:
-    name: 'Terraform Apply'
-    needs: terraform-plan
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    runs-on: ubuntu-latest
-    environment: production
-
-    defaults:
-      run:
-        shell: bash
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-
-    - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v3
-      with:
-        cli_config_credentials_token: ${{ env.TF_API_TOKEN }}
-
-    - name: Terraform Init
-      run: terraform init -input=false
-
-    - name: Terraform Apply
-      run: terraform apply -auto-approve -input=false      
+  deploy:
+    uses: Grupo-118-Tech-Challenge-Fiap-11SOAT/terraform-template-pipeline-grupo118-fase-3/.github/workflows/terraform-template-creation-resource.yml@main
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      TF_API_TOKEN: ${{ secrets.TF_API_TOKEN }}

--- a/.github/workflows/destroyresources.yml
+++ b/.github/workflows/destroyresources.yml
@@ -1,41 +1,14 @@
 name: 'Destroy Terraform Resources'
 
 on:
-  workflow_dispatch:
-
-env:
-  ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-  ARM_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-  ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-  ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-  TF_API_TOKEN: ${{ secrets.TF_API_TOKEN }}
+  workflow_dispatch: # Manual trigger
 
 jobs:
-  terraform-destroy:
-    name: 'Terraform Destroy'
-    if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    environment: production
-
-    defaults:
-      run:
-        shell: bash
-
-    steps:
-    # Checkout the repository to the GitHub Actions runner
-    - name: Checkout
-      uses: actions/checkout@v4
-
-    # Install the latest version of Terraform CLI 
-    - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v3
-      with:
-        cli_config_credentials_token: ${{ env.TF_API_TOKEN }}
-
-    # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
-    - name: Terraform Init
-      run: terraform init -input=false
-
-    # Run the destroy command to remove all resources defined in the Terraform configuration
-    - name: Terraform Destroy
-      run: terraform destroy -auto-approve -input=false
+  destroy:
+    uses: Grupo-118-Tech-Challenge-Fiap-11SOAT/terraform-template-pipeline-grupo118-fase-3/.github/workflows/terraform-template-destroy-resource.yml@main
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      TF_API_TOKEN: ${{ secrets.TF_API_TOKEN }}


### PR DESCRIPTION
This pull request refactors the GitHub Actions workflows for Terraform resource management by replacing the in-repo workflow definitions with reusable workflows from an external repository. The main goal is to simplify maintenance and promote consistency by leveraging shared templates for both resource creation and destruction.

**Workflow Refactoring and Reuse:**

* The `.github/workflows/createresources.yml` file now uses an external reusable workflow (`terraform-template-creation-resource.yml`) for deploying Terraform resources, removing all in-file job definitions and related environment variables. [[1]](diffhunk://#diff-44e0bbaaf5518a59ef5473806d29e12a80f1e4169766dba0e195ce16f00e0394L1-R1) [[2]](diffhunk://#diff-44e0bbaaf5518a59ef5473806d29e12a80f1e4169766dba0e195ce16f00e0394L12-R20)
* The `.github/workflows/destroyresources.yml` file is updated to use an external reusable workflow (`terraform-template-destroy-resource.yml`) for destroying Terraform resources, also removing all in-file job definitions and related environment variables.

**Secrets Management:**

* Both workflows now pass required Azure and Terraform secrets directly to the reusable workflows, ensuring secure and consistent secret handling. [[1]](diffhunk://#diff-44e0bbaaf5518a59ef5473806d29e12a80f1e4169766dba0e195ce16f00e0394L12-R20) [[2]](diffhunk://#diff-555171346fe607f3d4799cc31ce1ba1d91d0cb7c0f91ee79b8095932e8d9892eL4-R14)