### PR TITLE
feat: Simplify secret management by inheriting secrets in workflow files

### DIFF
--- a/.github/workflows/createresources.yml
+++ b/.github/workflows/createresources.yml
@@ -12,9 +12,4 @@ on:
 jobs:
   deploy:
     uses: Grupo-118-Tech-Challenge-Fiap-11SOAT/terraform-template-pipeline-grupo118-fase-3/.github/workflows/terraform-template-creation-resource.yml@main
-    secrets:
-      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-      AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-      TF_API_TOKEN: ${{ secrets.TF_API_TOKEN }}
+    secrets: inherit

--- a/.github/workflows/destroyresources.yml
+++ b/.github/workflows/destroyresources.yml
@@ -6,9 +6,4 @@ on:
 jobs:
   destroy:
     uses: Grupo-118-Tech-Challenge-Fiap-11SOAT/terraform-template-pipeline-grupo118-fase-3/.github/workflows/terraform-template-destroy-resource.yml@main
-    secrets:
-      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-      AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-      TF_API_TOKEN: ${{ secrets.TF_API_TOKEN }}
+    secrets: inherit


### PR DESCRIPTION
This pull request simplifies the way secrets are passed to workflow jobs in the GitHub Actions configuration. Instead of listing each secret individually, the workflows now use the `inherit` keyword to automatically pass all required secrets to the jobs.

Workflow configuration improvements:

* [`.github/workflows/createresources.yml`](diffhunk://#diff-44e0bbaaf5518a59ef5473806d29e12a80f1e4169766dba0e195ce16f00e0394L15-R15): Changed the `secrets` configuration for the `deploy` job to use `inherit`, streamlining secret management.
* [`.github/workflows/destroyresources.yml`](diffhunk://#diff-555171346fe607f3d4799cc31ce1ba1d91d0cb7c0f91ee79b8095932e8d9892eL9-R9): Updated the `secrets` configuration for the `destroy` job to use `inherit`, reducing manual secret specification.