### PR TITLE
chore: add comment to force build

### DIFF
--- a/.github/workflows/destroyresources.yml
+++ b/.github/workflows/destroyresources.yml
@@ -1,7 +1,7 @@
 name: 'Destroy Terraform Resources'
 
 on:
-  workflow_dispatch: # Manual trigger
+  workflow_dispatch: # Manual triggers
 
 jobs:
   destroy:


### PR DESCRIPTION
This pull request includes a minor update to the `.github/workflows/destroyresources.yml` workflow file, clarifying the comment for the `workflow_dispatch` event to indicate manual triggers.

* Updated the comment for `workflow_dispatch` to clarify that it refers to manual triggers in `.github/workflows/destroyresources.yml`.