### PR TITLE
feat: Add Azure Function resources and configuration to Terraform files

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -124,3 +124,25 @@ YAML
 }
 
 #endregion
+
+#region Azure Function
+module "infra_azure_function" {
+  source              = "./modules/azure-function"
+  resource_group_name = module.infra_resource_group.name
+  location            = module.infra_resource_group.location
+  function_os_type    = var.function_os_type
+  function_sku_name   = var.function_sku_name
+}
+
+output "azurefunction_hostname" {
+  value       = module.infra_azure_function.hostname
+  description = "The hostname of the Azure Function App created by the module"
+  
+}
+
+output "azurefunction_id" {
+  value       = module.infra_azure_function.id
+  description = "The ID of the Azure Function App created by the module"
+
+}
+#endregion

--- a/main.tf
+++ b/main.tf
@@ -137,7 +137,7 @@ module "infra_azure_function" {
 output "azurefunction_hostname" {
   value       = module.infra_azure_function.hostname
   description = "The hostname of the Azure Function App created by the module"
-  
+
 }
 
 output "azurefunction_id" {

--- a/modules/azure-function/main.tf
+++ b/modules/azure-function/main.tf
@@ -4,6 +4,7 @@ resource "azurerm_storage_account" "azurefunctionsa" {
   location                 = var.location
   account_tier             = "Standard"
   account_replication_type = "LRS"
+  account_kind             = "Storage"
 }
 
 resource "azurerm_storage_container" "azurefunctioncontainer" {
@@ -33,7 +34,7 @@ resource "azurerm_function_app_flex_consumption" "azurefunction" {
   runtime_name                = "dotnet-isolated"
   runtime_version             = 8.0
   maximum_instance_count      = 50
-  instance_memory_in_mb       = 2048
+  instance_memory_in_mb       = 512
 
   site_config {}
 

--- a/modules/azure-function/main.tf
+++ b/modules/azure-function/main.tf
@@ -32,7 +32,7 @@ resource "azurerm_function_app_flex_consumption" "azurefunction" {
   storage_authentication_type = "StorageAccountConnectionString"
   storage_access_key          = azurerm_storage_account.azurefunctionsa.primary_access_key
   runtime_name                = "dotnet-isolated"
-  runtime_version             = 8.0
+  runtime_version             = "8.0"
   maximum_instance_count      = 50
   instance_memory_in_mb       = 512
 

--- a/modules/azure-function/main.tf
+++ b/modules/azure-function/main.tf
@@ -1,0 +1,41 @@
+resource "azurerm_storage_account" "azurefunctionsa" {
+  name                     = "azurefunctionsafase3"
+  resource_group_name      = var.resource_group_name
+  location                 = var.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_storage_container" "azurefunctioncontainer" {
+  name                  = "azurefunctionsafase3-flexcontainer"
+  storage_account_id    = azurerm_storage_account.azurefunctionsa.id
+  container_access_type = "private"
+}
+
+resource "azurerm_service_plan" "azurefunctionsp" {
+  name                = "azurefunctionsafase3-app-service-plan"
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  os_type             = var.function_os_type
+  sku_name            = var.function_sku_name
+}
+
+resource "azurerm_function_app_flex_consumption" "azurefunction" {
+  name                = "TechChallengeFastFoodFunction"
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  service_plan_id     = azurerm_service_plan.azurefunctionsp.id
+
+  storage_container_type      = "blobContainer"
+  storage_container_endpoint  = "${azurerm_storage_account.azurefunctionsa.primary_blob_endpoint}${azurerm_storage_container.example.name}"
+  storage_authentication_type = "StorageAccountConnectionString"
+  storage_access_key          = azurerm_storage_account.azurefunctionsa.primary_access_key
+  runtime_name                = "dotnet-isolated"
+  runtime_version             = 8.0
+  maximum_instance_count      = 50
+  instance_memory_in_mb       = 2048
+
+  site_config {}
+
+}
+

--- a/modules/azure-function/main.tf
+++ b/modules/azure-function/main.tf
@@ -28,7 +28,7 @@ resource "azurerm_function_app_flex_consumption" "azurefunction" {
   service_plan_id     = azurerm_service_plan.azurefunctionsp.id
 
   storage_container_type      = "blobContainer"
-  storage_container_endpoint  = "${azurerm_storage_account.azurefunctionsa.primary_blob_endpoint}${azurerm_storage_container.example.name}"
+  storage_container_endpoint  = "${azurerm_storage_account.azurefunctionsa.primary_blob_endpoint}${azurerm_storage_container.azurefunctioncontainer.name}"
   storage_authentication_type = "StorageAccountConnectionString"
   storage_access_key          = azurerm_storage_account.azurefunctionsa.primary_access_key
   runtime_name                = "dotnet-isolated"
@@ -38,5 +38,12 @@ resource "azurerm_function_app_flex_consumption" "azurefunction" {
 
   site_config {}
 
+  app_settings = { 
+    "JwtKey" = "value",
+    "JwtIssuer" = "value",
+    "JwtAudience" = "value",
+    "JwtExpirationMinutes" = "value",
+    "SqlConnectionString" = "value"
+    }
 }
 

--- a/modules/azure-function/outputs.tf
+++ b/modules/azure-function/outputs.tf
@@ -1,0 +1,9 @@
+output "hostname" {
+  description = "The hostname of the Azure Function App."
+  value       = azurerm_function_app_flex_consumption.azurefunction.default_hostname
+}
+
+output "id" {
+  description = "The ID of the Azure Function App."
+  value       = azurerm_function_app_flex_consumption.azurefunction.id
+}

--- a/modules/azure-function/variables.tf
+++ b/modules/azure-function/variables.tf
@@ -1,0 +1,20 @@
+variable "location" {
+  description = "The Azure region where the resources will be created."
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "The name of the resource group where the resources will be created."
+  type        = string
+
+}
+
+variable "function_os_type" {
+  description = "The OS type for the Azure Function."
+  type        = string
+}
+
+variable "function_sku_name" {
+  description = "The SKU name for the Azure Function."
+  type        = string
+}

--- a/variables.tf
+++ b/variables.tf
@@ -39,3 +39,15 @@ variable "aks_name" {
   type        = string
   default     = "grupo118fase3infraaks"
 }
+
+variable "function_os_type" {
+  description = "The operating system type for the Azure Function App (e.g., Linux or Windows)"
+  type        = string
+  default     = "Linux"
+}
+
+variable "function_sku_name" {
+  description = "The SKU name for the Azure Function App Service Plan (e.g., Y1 for Consumption, EP1 for Premium)"
+  type        = string
+  default     = "FC1"
+}


### PR DESCRIPTION
This pull request introduces a new Terraform module to provision an Azure Function App and its supporting infrastructure. The changes include the creation of storage resources, a service plan, and the function app itself, along with the necessary variables and outputs to support flexible configuration and integration with the main infrastructure.

**Azure Function Infrastructure Addition:**

* Added a new module `azure-function` that provisions:
  - An Azure Storage Account and Blob Container for function storage.
  - An Azure App Service Plan configured for the specified OS and SKU.
  - An Azure Function App (flex consumption plan) with customizable runtime and scaling options.

**Configuration and Integration:**

* Updated the root `main.tf` to include the new `infra_azure_function` module, passing resource group, location, and function configuration variables.
* Added outputs in both the root and module to expose the Azure Function App's hostname and resource ID. [[1]](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbR127-R148) [[2]](diffhunk://#diff-663a55f9488987774b51f2cf70dcc641dd43bd4567a26c0d3e442da9f5672227R1-R9)

**Variable Management:**

* Introduced new variables in both the root and module to configure the function's OS type and SKU, with sensible defaults provided. [[1]](diffhunk://#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288eR42-R53) [[2]](diffhunk://#diff-a2a324c7a4bb9e246c1093897157604b8ecacaefd73d1d22c3d3a346647c24beR1-R20)