### PR TITLE
feat: Update email format in Azure Function configuration

### DIFF
--- a/modules/azure-api-management/main.tf
+++ b/modules/azure-api-management/main.tf
@@ -219,7 +219,7 @@ resource "azurerm_api_management_user" "group118fase3infraapimuser" {
   resource_group_name = var.resource_group_name
   first_name          = "Example"
   last_name           = "User"
-  email               = var.publisher_email
+  email               = "user1${var.publisher_email}"
   state               = "active"
   password            = random_password.apim_user_password.result
 }


### PR DESCRIPTION
This pull request makes a small change to how the email address is set for the `azurerm_api_management_user` resource. The email is now prefixed with "user1", likely to ensure uniqueness or follow a naming convention.